### PR TITLE
Corriger les liens des actus cassés

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@ agressions sexistes)</dd>
             <h2 class="center nd_brand">Les dernières actus</h2>
             <div class="row">
               <div class="col s12 m4">
-                <a href="#" target="_blank">
+                <a href="" target="_blank">
                   <div class="card small hoverable">
                     <div class="card-image">
                     </div>
@@ -338,7 +338,7 @@ agressions sexistes)</dd>
                 </a>
               </div>
               <div class="col s12 m4">
-                <a href="#" target="_blank">
+                <a href="" target="_blank">
                   <div class="card small hoverable">
                     <div class="card-image">
                     </div>
@@ -350,7 +350,7 @@ agressions sexistes)</dd>
                 </a>
               </div>
               <div class="col s12 m4">
-                <a href="#" target="_blank">
+                <a href="" target="_blank">
                   <div class="card small hoverable">
                     <div class="card-image">
                     </div>
@@ -365,7 +365,7 @@ agressions sexistes)</dd>
             </div>
             <div class="row">
               <div class="col s12 m4">
-                <a href="#" target="_blank">
+                <a href="" target="_blank">
                   <div class="card small hoverable">
                     <div class="card-image">
                     </div>
@@ -376,7 +376,7 @@ agressions sexistes)</dd>
                 </a>
               </div>
               <div class="col s12 m4">
-                <a href="#" target="_blank">
+                <a href="" target="_blank">
                   <div class="card small hoverable">
                     <div class="card-image">
                     </div>
@@ -388,7 +388,7 @@ agressions sexistes)</dd>
                 </a>
               </div>
               <div class="col s12 m4">
-                <a href="#" target="_blank">
+                <a href="" target="_blank">
                   <div class="card small hoverable">
                     <div class="card-image">
                     </div>


### PR DESCRIPTION
J'ai retiré les href="#" qui cassaient les liens des actus du fait du selecteur jQuery suivant:

```
 $('a[href^="#"]').on('click',function (e) {
    e.preventDefault();
 }
```

Les liens sont remplacés via l'API ensuite, mais le selecteur a déjà fait son taf
